### PR TITLE
【BE】勤怠イベント追加のクエリの実装

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,17 +1,19 @@
 import { Module } from '@nestjs/common';
 import { PrismaModule } from './prisma/prisma.module';
 import { LoggerModule } from './config/logger.module';
-import { AttendanceRecordModule } from './command/attendance-record.module';
+import { AttendanceRecordModule as CommandAttendanceRecordModule } from './command/attendance-record.module';
 import { AttendanceCorrectionModule } from './command/attendance-correction.module';
 import { AttendanceRuleModule } from './command/attendance-rule.module';
+import { AttendanceRecordModule as QueryAttendanceRecordModule } from './query/attendance-record.module';
 
 @Module({
   imports: [
     LoggerModule,
     PrismaModule,
-    AttendanceRecordModule,
+    CommandAttendanceRecordModule,
     AttendanceCorrectionModule,
     AttendanceRuleModule,
+    QueryAttendanceRecordModule,
   ],
   controllers: [],
   providers: [],

--- a/backend/src/query/attendance-record.module.ts
+++ b/backend/src/query/attendance-record.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { AttendanceRecordDaoPrisma } from './dao/attendance-record.dao.prisma';
+import { ATTENDANCE_RECORD_DAO } from './usecase/attendance-record/attendance-record-dao.tokens';
+import { GetAttendanceRecordUseCase } from './usecase/attendance-record/get-attendance-record.use-case';
+import { AttendanceRecordController } from './controller/attendance-record-controller';
+
+@Module({
+  controllers: [AttendanceRecordController],
+  providers: [
+    GetAttendanceRecordUseCase,
+    {
+      provide: ATTENDANCE_RECORD_DAO,
+      useClass: AttendanceRecordDaoPrisma,
+    },
+  ],
+  exports: [ATTENDANCE_RECORD_DAO],
+})
+export class AttendanceRecordModule {}

--- a/backend/src/query/controller/attendance-record-controller.ts
+++ b/backend/src/query/controller/attendance-record-controller.ts
@@ -1,0 +1,24 @@
+import { Body, Controller, HttpCode, Post } from '@nestjs/common';
+import { ZodValidationPipe } from '../../common/pipes/zod-validation.pipe';
+import { GetAttendanceRecordUseCase } from '../usecase/attendance-record/get-attendance-record.use-case';
+import {
+  type GetEventRequestDto,
+  getEventRequestSchema,
+} from '../request/getEventRequest';
+import type { GetEventResponseDto } from '../response/getEventResponse';
+
+@Controller('attendance-record')
+export class AttendanceRecordController {
+  constructor(
+    private readonly getAttendanceRecordUseCase: GetAttendanceRecordUseCase,
+  ) {}
+
+  @Post()
+  @HttpCode(200)
+  async getAttendanceEvents(
+    @Body(new ZodValidationPipe(getEventRequestSchema))
+    body: GetEventRequestDto,
+  ): Promise<GetEventResponseDto> {
+    return this.getAttendanceRecordUseCase.execute(body);
+  }
+}

--- a/backend/src/query/dao/attendance-record.dao.prisma.ts
+++ b/backend/src/query/dao/attendance-record.dao.prisma.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import {
+  AttendanceRecordParams,
+  IAttendanceRecordDao,
+} from '../usecase/attendance-record/attendance-record-dao.interface';
+import { PunchEvent } from '../type/attendace-record/punch-events';
+
+@Injectable()
+export class AttendanceRecordDaoPrisma implements IAttendanceRecordDao {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findByUserIdAndWorkDate(
+    params: AttendanceRecordParams,
+  ): Promise<PunchEvent[]> {
+    const record = await this.prisma.attendanceRecord.findUnique({
+      where: {
+        userId_workDate: {
+          userId: params.userId,
+          workDate: params.workDate,
+        },
+      },
+      include: {
+        punchEvents: {
+          orderBy: { occurredAt: 'asc' },
+        },
+      },
+    });
+
+    if (!record) {
+      return [];
+    }
+
+    return record.punchEvents.map((e) => ({
+      punchType: e.punchType,
+      occurredAt: e.occurredAt,
+      createdAt: e.createdAt,
+      source: e.source,
+      sourceId: e.sourceId ?? undefined,
+    }));
+  }
+}

--- a/backend/src/query/request/getEventRequest.ts
+++ b/backend/src/query/request/getEventRequest.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+import { INVALID_FORMAT, REQUIRED_FIELD } from '../../common/constants';
+import { workDateFromJsonSchema } from '../../common/utils/zod-helpers';
+
+export const getEventRequestSchema = z.object({
+  userId: z
+    .string()
+    .min(1, REQUIRED_FIELD('ユーザーID'))
+    .ulid({ message: INVALID_FORMAT('ユーザーID') }),
+  workDate: workDateFromJsonSchema('勤務日'),
+});
+
+export type GetEventRequestDto = z.infer<typeof getEventRequestSchema>;

--- a/backend/src/query/response/getEventResponse.ts
+++ b/backend/src/query/response/getEventResponse.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+import { PUNCH_TYPE } from '../type/attendace-record/punch-type';
+import { PUNCH_SOURCE } from '../type/attendace-record/punch-source';
+
+const punchEventResponseSchema = z.object({
+  punchType: z.enum([
+    PUNCH_TYPE.CLOCK_IN,
+    PUNCH_TYPE.CLOCK_OUT,
+    PUNCH_TYPE.BREAK_START,
+    PUNCH_TYPE.BREAK_END,
+  ]),
+  occurredAt: z.string().datetime(),
+  createdAt: z.string().datetime().optional(),
+  source: z.enum([PUNCH_SOURCE.NORMAL, PUNCH_SOURCE.CORRECTION]),
+  sourceId: z.string().nullable().optional(),
+});
+
+export const getEventResponseSchema = z.array(punchEventResponseSchema);
+
+export type GetEventResponseDto = z.infer<typeof getEventResponseSchema>;

--- a/backend/src/query/type/attendace-record/punch-events.ts
+++ b/backend/src/query/type/attendace-record/punch-events.ts
@@ -1,0 +1,10 @@
+import { PunchSource } from 'src/query/type/attendace-record/punch-source';
+import { PunchType } from 'src/query/type/attendace-record/punch-type';
+
+export type PunchEvent = {
+  punchType: PunchType;
+  occurredAt: Date;
+  createdAt?: Date;
+  source: PunchSource;
+  sourceId?: string;
+};

--- a/backend/src/query/type/attendace-record/punch-source.ts
+++ b/backend/src/query/type/attendace-record/punch-source.ts
@@ -1,0 +1,5 @@
+export const PUNCH_SOURCE = {
+  NORMAL: 'NORMAL',
+  CORRECTION: 'CORRECTION',
+} as const;
+export type PunchSource = (typeof PUNCH_SOURCE)[keyof typeof PUNCH_SOURCE];

--- a/backend/src/query/type/attendace-record/punch-type.ts
+++ b/backend/src/query/type/attendace-record/punch-type.ts
@@ -1,0 +1,7 @@
+export const PUNCH_TYPE = {
+  CLOCK_IN: 'CLOCK_IN',
+  CLOCK_OUT: 'CLOCK_OUT',
+  BREAK_START: 'BREAK_START',
+  BREAK_END: 'BREAK_END',
+} as const;
+export type PunchType = (typeof PUNCH_TYPE)[keyof typeof PUNCH_TYPE];

--- a/backend/src/query/usecase/attendance-record/attendance-record-dao.interface.ts
+++ b/backend/src/query/usecase/attendance-record/attendance-record-dao.interface.ts
@@ -1,0 +1,12 @@
+import { PunchEvent } from 'src/query/type/attendace-record/punch-events';
+
+export type AttendanceRecordParams = {
+  userId: string;
+  workDate: Date;
+};
+
+export interface IAttendanceRecordDao {
+  findByUserIdAndWorkDate(
+    params: AttendanceRecordParams,
+  ): Promise<PunchEvent[]>;
+}

--- a/backend/src/query/usecase/attendance-record/attendance-record-dao.tokens.ts
+++ b/backend/src/query/usecase/attendance-record/attendance-record-dao.tokens.ts
@@ -1,0 +1,1 @@
+export const ATTENDANCE_RECORD_DAO = Symbol('ATTENDANCE_RECORD_DAO');

--- a/backend/src/query/usecase/attendance-record/get-attendance-record.use-case.ts
+++ b/backend/src/query/usecase/attendance-record/get-attendance-record.use-case.ts
@@ -1,0 +1,37 @@
+import { Inject, Injectable } from '@nestjs/common';
+import type { IAttendanceRecordDao } from './attendance-record-dao.interface';
+import { ATTENDANCE_RECORD_DAO } from './attendance-record-dao.tokens';
+import type { GetEventResponseDto } from '../../response/getEventResponse';
+
+export type GetAttendanceRecordParams = {
+  userId: string;
+  workDate: Date;
+};
+
+@Injectable()
+export class GetAttendanceRecordUseCase {
+  constructor(
+    @Inject(ATTENDANCE_RECORD_DAO)
+    private readonly attendanceRecordDao: IAttendanceRecordDao,
+  ) {}
+
+  async execute(
+    params: GetAttendanceRecordParams,
+  ): Promise<GetEventResponseDto> {
+    // workDateFromJsonSchemaで既にUTCの0時に正規化されているため、そのまま使用
+    // DBのworkDateはDATE型なので、UTCの0時として扱われる
+    const punchEvents = await this.attendanceRecordDao.findByUserIdAndWorkDate({
+      userId: params.userId,
+      workDate: params.workDate,
+    });
+
+    // Date型をISO文字列に変換
+    return punchEvents.map((event) => ({
+      punchType: event.punchType,
+      occurredAt: event.occurredAt.toISOString(),
+      createdAt: event.createdAt?.toISOString(),
+      source: event.source,
+      sourceId: event.sourceId ?? null,
+    }));
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ユーザーと勤務日を指定して勤務記録を取得できる新しいAPI エンドポイントを追加しました。
  * 出勤・退勤・休憩開始・休憩終了などのパンチイベント情報を照会できるようになりました。
  * リクエストデータの自動バリデーション機能を実装しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->